### PR TITLE
httpd configuration: allow external access to api endpoint

### DIFF
--- a/root/etc/httpd/conf.d/tancredi.conf
+++ b/root/etc/httpd/conf.d/tancredi.conf
@@ -3,7 +3,6 @@
 </Location>
 
 <Location "/tancredi/api/v1">
-    Require ip 127.0.0.1
     ProxyPass "fcgi://127.0.0.1:9605/usr/share/tancredi/public/api-v1.php"
 </Location>
 


### PR DESCRIPTION
request will arrive directly from user's browser address, not from localhost