### PR TITLE
Fix log directory owner and permissions

### DIFF
--- a/nethserver-tancredi.spec
+++ b/nethserver-tancredi.spec
@@ -53,7 +53,7 @@ mkdir -p %{buildroot}/var/lib/tancredi/data/{first_access_tokens,scopes,template
     --dir /var/lib/tancredi/data/scopes 'attr(0770,root,apache)' \
     --dir /var/lib/tancredi/data/templates-custom 'attr(0770,root,apache)' \
     --dir /var/lib/tancredi/data/tokens 'attr(0770,root,apache)' \
-    --dir /var/log/tancredi 'attr(0770,root,apache)' \
+    --dir /var/log/tancredi 'attr(0750,apache,apache)' \
     > filelist
 
 %files -f filelist


### PR DESCRIPTION
/etc/cron.daily/logrotate:

error: skipping "/var/log/tancredi/tancredi.log" because parent
directory has insecure permissions (It's world writable or writable by
group which is not "root") Set "su" directive in config file to tell
logrotate which user/group should be used for rotation.
error: skipping "/var/log/tancredi/slow.log" because parent directory
has insecure permissions (It's world writable or writable by group which
is not "root") Set "su" directive in config file to tell logrotate which
user/group should be used for rotation.
error: skipping "/var/log/tancredi/error.log" because parent directory
has insecure permissions (It's world writable or writable by group which
is not "root") Set "su" directive in config file to tell logrotate which
user/group should be used for rotation.