### PR TITLE
Honor system timezone and logrotate settings

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -6,6 +6,7 @@ my $event = 'nethserver-tancredi-update';
 event_templates($event, qw(
     /etc/tancredi.conf
     /etc/httpd/conf.d/tancredi.conf
+    /etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf
 ));
 
 event_actions($event, qw(
@@ -35,5 +36,16 @@ event_templates($event, qw(
 
 event_services($event, qw(
     httpd reload
+));
+
+#
+# nethserver-php-update event -- catch timezone changes
+#
+event_templates('nethserver-php-update', qw(
+    /etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf
+));
+
+event_actions('nethserver-php-update', qw(
+    rh-php56-php-fpm reload
 ));
 

--- a/nethserver-tancredi.spec
+++ b/nethserver-tancredi.spec
@@ -4,7 +4,7 @@ Version: 1.0.0
 Release: 1%{?dist}
 License: GPLv3
 Source: %{name}-%{version}.tar.gz
-Source1: https://github.com/nethesis/tancredi/archive/9d2f7509036ed74e39a2012e78fc67849a1b7658/tancredi.tar.gz
+Source1: https://github.com/nethesis/tancredi/archive/bb2e378fcb1335077116b8cba852df4675bf6cd5/tancredi.tar.gz
 BuildArch: noarch
 
 BuildRequires: nethserver-devtools

--- a/root/etc/e-smith/templates/etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf/10base
@@ -19,10 +19,10 @@ pm.start_servers = 5
 pm.min_spare_servers = 5
 pm.max_spare_servers = 35
 
-slowlog = /var/log/tancredi/slow.log
+slowlog = /var/opt/rh/rh-php56/log/php-fpm/tancredi-slow.log
 request_slowlog_timeout = 5s
 
-php_admin_value[error_log] = /var/log/tancredi/error.log
+php_admin_value[error_log] = /var/opt/rh/rh-php56/log/php-fpm/tancredi.log
 php_admin_flag[log_errors] = on
 
 php_value[upload_max_filesize] = 2M

--- a/root/etc/e-smith/templates/etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf/10base
@@ -1,6 +1,7 @@
-#
-# PHP instance for Tancredi
-#
+
+;
+; PHP instance for Tancredi
+;
 
 [tancredi]
 env[PATH] = '/opt/rh/rh-php56/root/bin:/opt/rh/rh-php56/root/usr/bin:/usr/bin:$PATH'
@@ -28,3 +29,5 @@ php_value[upload_max_filesize] = 2M
 php_value[post_max_size] = 2M
 
 php_admin_flag[expose_php] = off
+
+php_value[date.timezone] = "{ $php{'DateTimezone'} || 'UTC' }"

--- a/root/etc/e-smith/templates/etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf/template-begin
+++ b/root/etc/e-smith/templates/etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf/template-begin
@@ -1,0 +1,9 @@
+;                  DO NOT MODIFY THIS FILE
+; Manual changes will be lost when this file is regenerated.
+;
+; Please read the developer's guide, which is available
+; at https://dev.nethesis.it/projects/nethserver/wiki/NethServer
+; original work from http://www.contribs.org/development/
+;
+; Copyright (C) 2020 Nethesis S.r.l.
+; http://www.nethesis.it - support@nethesis.it

--- a/root/etc/e-smith/templates/etc/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/tancredi.conf/10base
@@ -1,6 +1,5 @@
-logfile = "/var/log/tancredi/tancredi.log"
-loglevel = "DEBUG"
 
+loglevel = "ERROR"
 rw_dir = "/var/lib/tancredi/data/"
 ro_dir = "/usr/share/tancredi/data/"
 

--- a/root/etc/e-smith/templates/etc/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/tancredi.conf/10base
@@ -1,8 +1,19 @@
 
+; Tancredi log verbosity level. Allowed level names are
+;  - DEBUG (default)
+;  - INFO
+;  - WARNING
+;  - ERROR
+; Log messages sent to error_log()
 loglevel = "ERROR"
+
+; Directory where Tancredi has Read/Write access
 rw_dir = "/var/lib/tancredi/data/"
+
+; Directory where Tancredi has Read access
 ro_dir = "/usr/share/tancredi/data/"
 
+; provisioning_url_path and api_url_path depends on your web server configuration
 provisioning_url_path = "/provisioning/"
 api_url_path = "/tancredi/api/v1/"
 

--- a/root/etc/e-smith/templates/etc/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/tancredi.conf/10base
@@ -4,8 +4,11 @@
 ;  - INFO
 ;  - WARNING
 ;  - ERROR
-; Log messages sent to error_log()
-loglevel = "ERROR"
+; Comment this line for templates development:
+loglevel = "INFO"
+
+; Send messages to our log file
+logfile = "/var/log/tancredi/tancredi.log"
 
 ; Directory where Tancredi has Read/Write access
 rw_dir = "/var/lib/tancredi/data/"

--- a/root/etc/e-smith/templates/etc/tancredi.conf/30runtime_filter
+++ b/root/etc/e-smith/templates/etc/tancredi.conf/30runtime_filter
@@ -1,3 +1,5 @@
+
+; Retrieve some values from the Asterisk database
 runtime_filters = "AsteriskRuntimeFilter"
 astdb = "/var/lib/asterisk/astdb.sqlite3"
 

--- a/root/etc/logrotate.d/tancredi
+++ b/root/etc/logrotate.d/tancredi
@@ -3,5 +3,5 @@
 /var/log/tancredi/error.log {
    missingok
    delaycompress
-   create 0644 apache apache
+   create 0640 apache apache
 }

--- a/root/etc/logrotate.d/tancredi
+++ b/root/etc/logrotate.d/tancredi
@@ -1,4 +1,4 @@
-/var/log/tancredi/tancredi.log {
+/var/log/tancredi/*log {
    missingok
    delaycompress
    create 0640 apache apache

--- a/root/etc/logrotate.d/tancredi
+++ b/root/etc/logrotate.d/tancredi
@@ -2,8 +2,6 @@
 /var/log/tancredi/slow.log
 /var/log/tancredi/error.log {
    missingok
-   rotate 1
-   compress
-   weekly
+   delaycompress
    create 0644 apache apache
 }

--- a/root/etc/logrotate.d/tancredi
+++ b/root/etc/logrotate.d/tancredi
@@ -1,6 +1,4 @@
-/var/log/tancredi/tancredi.log
-/var/log/tancredi/slow.log
-/var/log/tancredi/error.log {
+/var/log/tancredi/tancredi.log {
    missingok
    delaycompress
    create 0640 apache apache


### PR DESCRIPTION
- Make a template of /etc/opt/rh/rh-php56/php-fpm.d/tancredi.conf
- Reload FPM config during nethserver-php-update event
- Requires https://github.com/nethesis/tancredi/pull/103 to fully work
- Fix logrotate settings to inherit from /etc/logrotate.conf

https://github.com/nethesis/dev/issues/5773

