### PR TITLE
Send firmware files with mod_xsendfile

### DIFF
--- a/nethserver-tancredi.spec
+++ b/nethserver-tancredi.spec
@@ -12,6 +12,7 @@ BuildRequires: rh-php56-php-cli, rh-php56-php-mbstring, rh-php56-php-xml, compos
 Requires: nethserver-rh-php56-php-fpm
 Requires: nethserver-httpd
 Requires: nethserver-freepbx
+Requires: mod_xsendfile
 
 %description
 Tancredi provisioning engine packaging and configuration
@@ -45,7 +46,7 @@ perl createlinks
 )
 install NethVoiceAuth.php %{buildroot}/usr/share/tancredi/src/Entity/
 install AsteriskRuntimeFilter.php %{buildroot}/usr/share/tancredi/src/Entity/
-mkdir -p %{buildroot}/var/lib/tancredi/data/{first_access_tokens,scopes,templates-custom,tokens}
+mkdir -p %{buildroot}/var/lib/tancredi/data/{first_access_tokens,scopes,templates-custom,tokens,firmware}
 
 %{genfilelist} %{buildroot} \
     --file /etc/tancredi.conf 'attr(0644,root,root) %config(noreplace)' \
@@ -53,6 +54,7 @@ mkdir -p %{buildroot}/var/lib/tancredi/data/{first_access_tokens,scopes,template
     --dir /var/lib/tancredi/data/scopes 'attr(0770,root,apache)' \
     --dir /var/lib/tancredi/data/templates-custom 'attr(0770,root,apache)' \
     --dir /var/lib/tancredi/data/tokens 'attr(0770,root,apache)' \
+    --dir /var/lib/tancredi/data/firmware 'attr(0775,root,apache)' \
     --dir /var/log/tancredi 'attr(0750,apache,apache)' \
     > filelist
 

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/tancredi.conf/10base
@@ -24,3 +24,5 @@
     ProxyPass "fcgi://127.0.0.1:9605/usr/share/tancredi/public/api-v1.php"
 </Location>
 
+XSendFile on
+XSendFilePath /var/lib/tancredi/data/firmware

--- a/root/etc/e-smith/templates/etc/tancredi.conf/40file_reader
+++ b/root/etc/e-smith/templates/etc/tancredi.conf/40file_reader
@@ -1,0 +1,5 @@
+; Methods to return static files to the client:
+; - native - use PHP itself (default)
+; - apache - return X-Sendfile header
+; - nginx - return X-Accel-Redirect
+file_reader = "apache"


### PR DESCRIPTION
The Apache mod_xsendfile from the EPEL repo allows PHP to offload the task of returning big firmware files onto Apache itself. Apache is good for static files and can add ETag and other useful headers.

https://github.com/nethesis/dev/issues/5776

Requires: https://github.com/nethesis/tancredi/pull/124
