### PR TITLE
Suppress log warning

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-tancredi-conf
+++ b/root/etc/e-smith/events/actions/nethserver-tancredi-conf
@@ -80,4 +80,4 @@ if [[ ! -f ${dst_file} ]]; then
 fi
 
 # Launch upgrade script as apache to preserve filesystem permissions
-su -s /bin/bash -c "/usr/bin/scl enable rh-php56 -- php /usr/share/tancredi/scripts/upgrade.php" - apache
+runuser -s /bin/bash -c "/usr/bin/scl enable rh-php56 -- php /usr/share/tancredi/scripts/upgrade.php" - apache


### PR DESCRIPTION
It seems su complains about a missing TTY (?) or similar.
As the action is non-interactive and is running as root,
runas provides a faster and simpler solution.

This is the log entry:

    su: (to apache) root on none

https://github.com/nethesis/dev/issues/5812

See also https://github.com/nethesis/tancredi/pull/163/commits/f3edb3ebe0388151d645e4d1b7d4575ea2a1e68e