### PR TITLE
Fix conflict with nethserver-httpd-virtualhosts

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -48,6 +48,6 @@ event_templates('nethserver-php-update', qw(
 ));
 
 event_services('nethserver-php-update', qw(
-    rh-php73-php-fpm reload
+    rh-php73-php-fpm restart
 ));
 


### PR DESCRIPTION
nethserver-httpd-virtualhosts uses restart
https://github.com/NethServer/nethserver-httpd/blob/63d72b2557aae536192bcbf9cafd2cc86ce7da01/createlinks-virtualhosts#L138
and using restart too should avoid the conflict