### PR TITLE
Add ipv6 localhost address to httpd conf

### DIFF
--- a/root/etc/e-smith/templates/etc/httpd/conf.d/tancredi.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/tancredi.conf/10base
@@ -20,7 +20,7 @@
 </Location>
 
 <Location "/tancredi/api/v1">
-    Require ip {$localAccess} {$validFrom}
+    Require ip {$localAccess} ::1 {$validFrom}
     ProxyPass "fcgi://127.0.0.1:9605/usr/share/tancredi/public/api-v1.php"
 </Location>
 


### PR DESCRIPTION
Add ::1, ipv6 localhost address to host allowed to access the tancredi APIs. This is because if ipv6 localhost exists in hosts file, it is used in communication from localhost. Usually ipv6 localhost isn't enabled, but sometime it is in some VPS installations
https://github.com/nethesis/dev/issues/6228